### PR TITLE
`TextSection` Component

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -47,7 +47,7 @@ function Footer({ config }: IFooterProps) {
               <Text variation="a" className="font-bold mb-3 text-base">{section.title}</Text>
             </Link>
             {section.items?.map((item) => (
-              <Link key={item.to} href={item.to} passHref>
+              <Link key={item.title} href={item.to} passHref>
                 <Text variation="a" className="text-base">{item.title}</Text>
               </Link>
             ))}

--- a/components/Text/constants.ts
+++ b/components/Text/constants.ts
@@ -3,27 +3,27 @@ import { TTextVariationConfig } from './types';
 export const variationConfig: TTextVariationConfig = {
   h1: {
     component: 'h1',
-    defaultClassNames: 'md:text-h1 text-display font-bold text-3xl',
+    defaultClassNames: 'md:text-h1 font-display font-bold text-3xl',
   },
   h2: {
     component: 'h2',
-    defaultClassNames: 'text-h2 text-display font-semibold',
+    defaultClassNames: 'text-h2 font-display font-semibold',
   },
   h3: {
     component: 'h3',
-    defaultClassNames: 'text-h3 text-display text-primary',
+    defaultClassNames: 'text-h3 font-display text-primary',
   },
   h4: {
     component: 'h4',
-    defaultClassNames: 'text-h4 text-display font-semibold',
+    defaultClassNames: 'text-h4 font-display font-semibold',
   },
   highlighted: {
     component: 'p',
-    defaultClassNames: 'text-highlighted text-display uppercase font-bold opacity-20',
+    defaultClassNames: 'lg:text-highlighted text-h2 font-display uppercase font-bold opacity-20 whitespace-pre-line',
   },
   p: {
     component: 'p',
-    defaultClassNames: 'text-lg',
+    defaultClassNames: 'text-p',
   },
   quote: {
     component: 'p',

--- a/components/Text/index.tsx
+++ b/components/Text/index.tsx
@@ -1,27 +1,33 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import clsx from 'clsx';
 
+import { forwardRef } from 'react';
 import { variationConfig } from './constants';
 import { getParsedChildren } from './utils';
 import { ITextProps } from './types';
 
-function Text({
-  children, className, isMarkdown, variation, ...props
-}: ITextProps) {
-  const {
-    component: TextComponent,
-    defaultClassNames,
-  } = variationConfig[variation!];
-  const parsedChildren = isMarkdown
-    ? getParsedChildren({ children: children as string })
-    : children;
+const Text = forwardRef(
+  ({
+    children,
+    className,
+    isMarkdown,
+    variation, ...props
+  }: ITextProps, ref) => {
+    const {
+      component: TextComponent,
+      defaultClassNames,
+    } = variationConfig[variation!];
+    const parsedChildren = isMarkdown
+      ? getParsedChildren({ children: children as string })
+      : children;
 
-  return (
-    <TextComponent {...props} className={clsx(defaultClassNames, className)}>
-      {parsedChildren}
-    </TextComponent>
-  );
-}
+    return (
+      <TextComponent {...props} className={clsx(defaultClassNames, className)} ref={variation === 'a' ? ref : null}>
+        {parsedChildren}
+      </TextComponent>
+    );
+  },
+);
 
 Text.defaultProps = {
   className: '',

--- a/components/Text/utils.tsx
+++ b/components/Text/utils.tsx
@@ -20,7 +20,7 @@ export function getParsedChildren({
     const textParts = children.split(/(\*.*?\*)/g);
     const newChildren = textParts.map((textPart) => {
       if (textPart.match(/((\*)(.*?)(\*))/g)) {
-        return <strong className={config?.strong.className}>{textPart.replace(/\*/g, '')}</strong>;
+        return <strong key={textPart} className={config?.strong.className}>{textPart.replace(/\*/g, '')}</strong>;
       }
 
       return textPart;

--- a/components/Text/utils.tsx
+++ b/components/Text/utils.tsx
@@ -9,7 +9,7 @@ interface IGetParsedChildrenProps {
 
 const defaultGetParsedChildrenConfig = {
   strong: {
-    className: 'relative before:absolute before:w-full before:h-1/4 before:md:h-2/6 before:bottom-1.5 before:left-0 before:bg-primary z-0 before:-z-10',
+    className: 'relative before:absolute before:w-full before:h-2/6 before:bottom-1/6 before:left-0 before:bg-primary z-0 before:-z-10',
   },
 };
 

--- a/components/TextSection/index.tsx
+++ b/components/TextSection/index.tsx
@@ -12,7 +12,7 @@ function TextSection({ className, items, title }: ITextSectionProps) {
           </div>
         )}
         {items.map((item) => (
-          <div className="flex gap-10 lg:gap-20 flex-wrap justify-center w-full">
+          <div key={item.title} className="flex gap-10 lg:gap-20 flex-wrap justify-center w-full">
             <div className="flex flex-auto md:flex-1 justify-start md:justify-end w-full lg:w-auto">
               <Text variation="highlighted" className="md:text-right translate-y-1">{item.highlight}</Text>
             </div>

--- a/components/TextSection/index.tsx
+++ b/components/TextSection/index.tsx
@@ -1,0 +1,34 @@
+import Text from '@components/Text';
+import clsx from 'clsx';
+import { ITextSectionProps } from './types';
+
+function TextSection({ className, items, title }: ITextSectionProps) {
+  return (
+    <section className={clsx('flex justify-center w-full py-20 px-4', className)}>
+      <div className="flex flex-col lg:gap-30 gap-20 max-w-u1280 w-full md:pr-12 items-center">
+        {title && (
+          <div className="flex justify-center gap-16">
+            <Text variation="h2" className="relative flex flex-col justify-center items-center before:mb-12 before:h-1 before:w-9 before:bg-white before:opacity-20 before:rounded-sm">{title}</Text>
+          </div>
+        )}
+        {items.map((item) => (
+          <div className="flex gap-10 lg:gap-20 flex-wrap justify-center w-full">
+            <div className="flex flex-auto md:flex-1 justify-start md:justify-end w-full lg:w-auto">
+              <Text variation="highlighted" className="md:text-right translate-y-1">{item.highlight}</Text>
+            </div>
+            <div className="flex flex-auto md:flex-1 flex-col gap-4 w-full">
+              <Text variation="h3">{item.title}</Text>
+              <Text variation="p">{item.content}</Text>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+TextSection.defaultProps = {
+  className: '',
+};
+
+export default TextSection;

--- a/components/TextSection/types.ts
+++ b/components/TextSection/types.ts
@@ -1,0 +1,9 @@
+export interface ITextSectionProps {
+  className?: string;
+  items: {
+    highlight: string;
+    title: string;
+    content: string;
+  }[];
+  title: string;
+}

--- a/constants/pages/index.ts
+++ b/constants/pages/index.ts
@@ -3,4 +3,19 @@ export const texts = {
     title: 'A *new kind* of product development partner',
     content: 'We are product development experts passionate about helping established companies to build successful software/tech products. We provide technical and product leadership coupled with high perform[...]',
   },
+  clients: {
+    title: 'Our clients',
+    items: [
+      {
+        highlight: 'Bring \ninnovative \nsolutions',
+        title: 'Who you are',
+        content: 'You are a stablished technology company, that have a proven business model, but you’re still defining product direction and making high level technical decisions. You are in the process of building a core development team and looking to establish strong software engineering practices. You are open to expanding your capacity as a service so you can leverage...',
+      },
+      {
+        highlight: 'Partner with \nexperienced\n professionals',
+        title: 'Your pains',
+        content: 'Your product backlog is ever growing and you can’t release features and fix issues quickly enough. Your roadmap needs further definition, both from a product and technical perspective. You realize that you need more product development capacity but at the same time need to establish a solid foundation of software engineering practices. You are frustrated with the amount of effort and time it takes to hire...',
+      },
+    ],
+  },
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import Hero from '@components/Hero';
 import DefaultLayout from '@components/Layouts/Default';
 import Text from '@components/Text';
+import TextSection from '@components/TextSection';
 import { texts } from '@constants/pages';
 
 function Home() {
@@ -8,8 +9,9 @@ function Home() {
     <DefaultLayout>
       <Hero className="py-20 md:py-40 px-4">
         <Text variation="h1" className="max-w-xl text-center" isMarkdown>{texts.hero.title}</Text>
-        <Text variation="p" className="max-w-xl text-center">{texts.hero.content}</Text>
+        <Text variation="p" className="max-w-xl text-center opacity-80">{texts.hero.content}</Text>
       </Hero>
+      <TextSection title={texts.clients.title} items={texts.clients.items} />
     </DefaultLayout>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,11 +4,11 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    fontFamily: {
-      display: ['Hind', 'system-ui', 'sans-serif'],
-      body: ['Red Hat Text', 'system-ui', 'sans-serif'],
-    },
     extend: {
+      fontFamily: {
+        display: ['Hind', 'system-ui', 'sans-serif'],
+        body: ['Red Hat Text', 'system-ui', 'sans-serif'],
+      },
       colors: {
         primary: '#4A5CFF',
         secondary: '#080C1F',
@@ -19,6 +19,7 @@ module.exports = {
         h2: ['2.25rem', '1.38'],
         h3: ['1.625rem', '1.6'],
         h4: ['1.375rem', '1.1'],
+        p: ['1.125rem', '1.9'],
         highlighted: ['3.5rem', '1'],
         quote: ['2.125rem', '1.3'],
       },
@@ -27,6 +28,16 @@ module.exports = {
       },
       padding: {
         18: '4.25rem',
+      },
+      gap: {
+        30: '7.75rem',
+      },
+      screens: {
+        lg: '1100px',
+      },
+      spacing: {
+        '1/5': '20%',
+        '1/6': '16.667%',
       },
     },
   },


### PR DESCRIPTION
# Summary
- Added `TextSection` component with responsive styles.
- Adjusted `Text` constants to use `font-display` on titles and special headings.
- Adjusted `Text` component to forward refs when variation is an `a` tag.

# Screenshots
<img width="560" alt="Screen Shot 2022-03-18 at 15 18 38 1" src="https://user-images.githubusercontent.com/3473831/159077621-be43b94c-604c-4b2a-a49f-0afcef3dc62d.png">
<img width="935" alt="Screen Shot 2022-03-18 at 15 18 31" src="https://user-images.githubusercontent.com/3473831/159077631-68a50c04-e55b-4a82-8946-c34feb52a885.png">
<img width="1399" alt="Screen Shot 2022-03-18 at 15 18 20" src="https://user-images.githubusercontent.com/3473831/159077692-08b3db5a-cfc2-4da7-ba81-53ddafe16b2f.png">

